### PR TITLE
Add master task framework

### DIFF
--- a/src/Master/MasterMain.java
+++ b/src/Master/MasterMain.java
@@ -1,0 +1,32 @@
+package Master;
+
+import Master.tasks.BankTask;
+import Master.tasks.CombatTask;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import org.dreambot.api.methods.Calculations;
+import org.dreambot.api.script.AbstractScript;
+import org.dreambot.api.script.Category;
+import org.dreambot.api.script.ScriptManifest;
+
+@ScriptManifest(category = Category.MISC, name = "Master", author = "Andrew", version = 1.0)
+public class MasterMain extends AbstractScript {
+
+    private final List<Task> tasks = new ArrayList<>();
+
+    @Override
+    public void onStart() {
+        tasks.add(new BankTask(this));
+        tasks.add(new CombatTask(this, "Chicken"));
+    }
+
+    @Override
+    public int onLoop() {
+        return tasks.stream()
+                .filter(Task::shouldExecute)
+                .max(Comparator.comparingInt(Task::priority))
+                .map(Task::execute)
+                .orElseGet(() -> Calculations.random(300, 600));
+    }
+}

--- a/src/Master/Task.java
+++ b/src/Master/Task.java
@@ -1,0 +1,27 @@
+package Master;
+
+/**
+ * Represents a unit of work that can be executed by the Master script.
+ */
+public interface Task {
+    /**
+     * Determines whether this task is ready to be executed.
+     *
+     * @return true if the task should run
+     */
+    boolean shouldExecute();
+
+    /**
+     * Performs the task's logic.
+     *
+     * @return delay in milliseconds before the next loop
+     */
+    int execute();
+
+    /**
+     * Priority used when multiple tasks are available. Higher values are run first.
+     *
+     * @return task priority
+     */
+    int priority();
+}

--- a/src/Master/tasks/BankTask.java
+++ b/src/Master/tasks/BankTask.java
@@ -1,0 +1,37 @@
+package Master.tasks;
+
+import Master.Task;
+import org.dreambot.api.methods.Calculations;
+import org.dreambot.api.script.AbstractScript;
+
+/**
+ * Handles banking when the inventory is full.
+ */
+public class BankTask implements Task {
+
+    private final AbstractScript ctx;
+
+    public BankTask(AbstractScript ctx) {
+        this.ctx = ctx;
+    }
+
+    @Override
+    public boolean shouldExecute() {
+        return ctx.getInventory().isFull();
+    }
+
+    @Override
+    public int execute() {
+        if (ctx.getBank().isOpen()) {
+            ctx.getBank().depositAllItems();
+        } else {
+            ctx.getBank().openClosest();
+        }
+        return Calculations.random(300, 600);
+    }
+
+    @Override
+    public int priority() {
+        return 10;
+    }
+}

--- a/src/Master/tasks/CombatTask.java
+++ b/src/Master/tasks/CombatTask.java
@@ -1,0 +1,40 @@
+package Master.tasks;
+
+import Master.Task;
+import org.dreambot.api.methods.Calculations;
+import org.dreambot.api.script.AbstractScript;
+import org.dreambot.api.wrappers.interactive.NPC;
+
+/**
+ * Simple combat task that attacks the specified NPC when available.
+ */
+public class CombatTask implements Task {
+
+    private final AbstractScript ctx;
+    private final String targetName;
+
+    public CombatTask(AbstractScript ctx, String targetName) {
+        this.ctx = ctx;
+        this.targetName = targetName;
+    }
+
+    @Override
+    public boolean shouldExecute() {
+        return !ctx.getInventory().isFull();
+    }
+
+    @Override
+    public int execute() {
+        NPC npc = ctx.getNpcs().closest(n -> n != null && n.getName().equals(targetName) && !n.isInCombat());
+        if (npc != null) {
+            npc.interact("Attack");
+            ctx.sleepUntil(() -> ctx.getLocalPlayer().isInCombat(), 2000);
+        }
+        return Calculations.random(200, 400);
+    }
+
+    @Override
+    public int priority() {
+        return 5;
+    }
+}


### PR DESCRIPTION
## Summary
- introduce Task interface to standardize script modules
- add MasterMain script that prioritizes and executes tasks
- create BankTask and CombatTask as examples of refactored modules

## Testing
- `javac $(find src/Master -name '*.java')` *(fails: package org.dreambot.api.* does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68abc59516cc832aadee8f6ab9eb1932