### PR TITLE
Add configuration callbacks and latch-based startup

### DIFF
--- a/src/Combat/src/Combat/Main.java
+++ b/src/Combat/src/Combat/Main.java
@@ -10,6 +10,7 @@ import org.dreambot.api.script.Category;
 import org.dreambot.api.script.ScriptManifest;
 import org.dreambot.api.wrappers.interactive.NPC;
 import org.dreambot.api.wrappers.items.GroundItem;
+import java.util.concurrent.CountDownLatch;
 
 @ScriptManifest(category = Category.COMBAT, name = "Combat.01", author = "Andrew", version = .01)
 
@@ -22,17 +23,20 @@ public class Main extends AbstractScript {
 	private GroundItem lootItem;
 
 	@Override
-	public void onStart() { //0th state
-		super.onStart();
-		s = new State();
-		while (s.getState() < 1) {
-			sleep(100);
-		}
-		for (String s : s.getLoot()) {
-			log("Looting:" + s);
-		}
-		init();
-	}
+public void onStart() { //0th state
+super.onStart();
+CountDownLatch latch = new CountDownLatch(1);
+s = new State(latch::countDown);
+try {
+latch.await();
+} catch (InterruptedException e) {
+e.printStackTrace();
+}
+for (String s : s.getLoot()) {
+log("Looting:" + s);
+}
+init();
+}
 
 	private void init() { //1st state
 		kArea = Area.generateArea(s.getFightRadius(), getLocalPlayer().getTile());

--- a/src/Combat/src/Handler/State.java
+++ b/src/Combat/src/Handler/State.java
@@ -11,26 +11,40 @@ import javax.swing.SwingUtilities;
 
 public class State {
 
-	private JFrame frame;
-	private Window window;
-	private boolean buryBones, takeOtherPlayersLoot;
-	private String target, food;
-	private int eatPercentage, bankLocation, foodAmt, fightRadius, state = 0;
-	private List<String> loot;
+private JFrame frame;
+private Window window;
+private boolean buryBones, takeOtherPlayersLoot;
+private String target, food;
+private int eatPercentage, bankLocation, foodAmt, fightRadius, state = 0;
+private List<String> loot;
+private Runnable onConfigComplete;
 
-	public State() {
-		SwingUtilities.invokeLater(() -> {
-			window = new Window(this);
-			setFrame(new JFrame(Window.TITLE));
-			getFrame().setSize(Window.W, Window.H);
-			getFrame().setLocationRelativeTo(null);
-			getFrame().setPreferredSize(new Dimension(Window.W, Window.H));
-			getFrame().setContentPane(window.getRootPanel());
-			getFrame().setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
-			getFrame().pack();
-			getFrame().setVisible(true);
-		});
-	}
+public State() {
+this(null);
+}
+
+public State(Runnable onConfigComplete) {
+this.onConfigComplete = onConfigComplete;
+SwingUtilities.invokeLater(() -> {
+window = new Window(this);
+setFrame(new JFrame(Window.TITLE));
+getFrame().setSize(Window.W, Window.H);
+getFrame().setLocationRelativeTo(null);
+getFrame().setPreferredSize(new Dimension(Window.W, Window.H));
+getFrame().setContentPane(window.getRootPanel());
+getFrame().setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+getFrame().pack();
+getFrame().setVisible(true);
+});
+}
+
+private void fireConfigComplete() {
+if (onConfigComplete != null) {
+Runnable cb = onConfigComplete;
+onConfigComplete = null;
+cb.run();
+}
+}
 
 	public void killFrame() {
 		try {
@@ -75,9 +89,12 @@ public class State {
 		return state;
 	}
 
-	public void setState(int s) {
-		state = s;
-	}
+public void setState(int s) {
+state = s;
+if (state >= 1) {
+fireConfigComplete();
+}
+}
 
 	public String getTarget() {
 		return target;

--- a/src/GoldCrafter/src/Craft/Main.java
+++ b/src/GoldCrafter/src/Craft/Main.java
@@ -11,6 +11,7 @@ import org.dreambot.api.script.AbstractScript;
 import org.dreambot.api.script.Category;
 import org.dreambot.api.script.ScriptManifest;
 import org.dreambot.api.wrappers.widgets.WidgetChild;
+import java.util.concurrent.CountDownLatch;
 
 @ScriptManifest(category = Category.CRAFTING, name = "Crafting.01", author = "Andrew", version = .01)
 
@@ -25,15 +26,17 @@ public class Main extends AbstractScript {
 	private WidgetChild wig;
 
 	@Override
-	public void onStart() { //0th state
-		super.onStart();
-		s = new State();
-		while (s.getState() < 1) {
-			log("Starting");
-			sleep(200);
-		}
-		init();
-	}
+public void onStart() { //0th state
+super.onStart();
+CountDownLatch latch = new CountDownLatch(1);
+s = new State(latch::countDown);
+try {
+latch.await();
+} catch (InterruptedException e) {
+e.printStackTrace();
+}
+init();
+}
 
 	private void init() { //1st state
 		bankArea = getBankArea();

--- a/src/GoldCrafter/src/Handler/State.java
+++ b/src/GoldCrafter/src/Handler/State.java
@@ -8,34 +8,48 @@ import javax.swing.SwingUtilities;
 
 public class State {
 
-	private JFrame frame;
-	private Window window;
-	private int state = 0, smeltLocation, product;
+       private JFrame frame;
+       private Window window;
+       private int state = 0, smeltLocation, product;
+       private Runnable onConfigComplete;
 
-	public State() {
-		SwingUtilities.invokeLater(() -> {
-			window = new Window(this);
-			frame = (new JFrame(Window.TITLE));
-			frame.setSize(Window.W, Window.H);
-			frame.setLocationRelativeTo(null);
-			frame.setPreferredSize(new Dimension(Window.W, Window.H));
-			frame.setContentPane(window.getRootPanel());
-			frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
-			frame.pack();
-			frame.setVisible(true);
-		});
-	}
+       public State() {
+               this(null);
+       }
 
-	public void killFrame() {
-		try {
-			frame.setVisible(false);
-			frame.dispose();
-			window.dispose();
-		} catch (Exception woeIsMe) {
-			woeIsMe.printStackTrace();
-		}
-		setState(1);
-	}
+       public State(Runnable onConfigComplete) {
+               this.onConfigComplete = onConfigComplete;
+               SwingUtilities.invokeLater(() -> {
+                       window = new Window(this);
+                       frame = (new JFrame(Window.TITLE));
+                       frame.setSize(Window.W, Window.H);
+                       frame.setLocationRelativeTo(null);
+                       frame.setPreferredSize(new Dimension(Window.W, Window.H));
+                       frame.setContentPane(window.getRootPanel());
+                       frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+                       frame.pack();
+                       frame.setVisible(true);
+               });
+       }
+
+       private void fireConfigComplete() {
+               if (onConfigComplete != null) {
+                       Runnable cb = onConfigComplete;
+                       onConfigComplete = null;
+                       cb.run();
+               }
+       }
+
+       public void killFrame() {
+               try {
+                       frame.setVisible(false);
+                       frame.dispose();
+                       window.dispose();
+               } catch (Exception woeIsMe) {
+                       woeIsMe.printStackTrace();
+               }
+               setState(1);
+       }
 
 	public int getSmeltLocation() {
 		return smeltLocation;
@@ -49,9 +63,12 @@ public class State {
 		return state;
 	}
 
-	public void setState(int s) {
-		state = s;
-	}
+       public void setState(int s) {
+               state = s;
+               if (state >= 1) {
+                       fireConfigComplete();
+               }
+       }
 
 
 	public int getProduct() {

--- a/src/Miner/archive/Miner/Handler/State.java
+++ b/src/Miner/archive/Miner/Handler/State.java
@@ -8,24 +8,38 @@ import javax.swing.SwingUtilities;
 
 public class State {
 
-	private JFrame frame;
-	private Window window;
-	private int radius, bankArea, state = 0;
-	private boolean drop;
+private JFrame frame;
+private Window window;
+private int radius, bankArea, state = 0;
+private boolean drop;
+private Runnable onConfigComplete;
 
-	public State() {
-		SwingUtilities.invokeLater(() -> {
-			window = new Window(this);
-			setFrame(new JFrame(Window.TITLE));
-			getFrame().setSize(Window.W, Window.H);
-			getFrame().setLocationRelativeTo(null);
-			getFrame().setPreferredSize(new Dimension(Window.W, Window.H));
-			getFrame().setContentPane(window.getRootPanel());
-			getFrame().setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
-			getFrame().pack();
-			getFrame().setVisible(true);
-		});
-	}
+public State() {
+this(null);
+}
+
+public State(Runnable onConfigComplete) {
+this.onConfigComplete = onConfigComplete;
+SwingUtilities.invokeLater(() -> {
+window = new Window(this);
+setFrame(new JFrame(Window.TITLE));
+getFrame().setSize(Window.W, Window.H);
+getFrame().setLocationRelativeTo(null);
+getFrame().setPreferredSize(new Dimension(Window.W, Window.H));
+getFrame().setContentPane(window.getRootPanel());
+getFrame().setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+getFrame().pack();
+getFrame().setVisible(true);
+});
+}
+
+private void fireConfigComplete() {
+if (onConfigComplete != null) {
+Runnable cb = onConfigComplete;
+onConfigComplete = null;
+cb.run();
+}
+}
 
 	public int getRadius() {
 		return radius;
@@ -74,9 +88,12 @@ public class State {
 		return state;
 	}
 
-	public void setState(int state) {
-		this.state = state;
-	}
+public void setState(int state) {
+this.state = state;
+if (state >= 1) {
+fireConfigComplete();
+}
+}
 
 	public JFrame getFrame() {
 		return frame;

--- a/src/Miner/archive/Miner/Main.java
+++ b/src/Miner/archive/Miner/Main.java
@@ -9,6 +9,7 @@ import org.dreambot.api.script.Category;
 import org.dreambot.api.script.ScriptManifest;
 import org.dreambot.api.wrappers.interactive.GameObject;
 import org.dreambot.api.wrappers.items.Item;
+import java.util.concurrent.CountDownLatch;
 
 @ScriptManifest(category = Category.MINING, name = "Miner.01", author = "Andrew", version = .01)
 public class Main extends AbstractScript {
@@ -17,14 +18,17 @@ public class Main extends AbstractScript {
 	private Area mArea, bankArea;
 
 	@Override
-	public void onStart() { //0th state
-		super.onStart();
-		s = new State();
-		while (s.getState() < 1) {
-			sleep(100);
-		}
-		init();
-	}
+public void onStart() { //0th state
+super.onStart();
+CountDownLatch latch = new CountDownLatch(1);
+s = new State(latch::countDown);
+try {
+latch.await();
+} catch (InterruptedException e) {
+e.printStackTrace();
+}
+init();
+}
 
 	private void init() { //1st state
 		mArea = Area.generateArea(s.getRadius(), getLocalPlayer().getTile());

--- a/src/Template/src/Handler/State.java
+++ b/src/Template/src/Handler/State.java
@@ -8,23 +8,37 @@ import javax.swing.SwingUtilities;
 
 public class State {
 
-	private JFrame frame;
-	private Window window;
-	private int state = 0;
+private JFrame frame;
+private Window window;
+private int state = 0;
+private Runnable onConfigComplete;
 
-	public State() {
-		SwingUtilities.invokeLater(() -> {
-			window = new Window(this);
-			frame = (new JFrame(Window.TITLE));
-			frame.setSize(Window.W, Window.H);
-			frame.setLocationRelativeTo(null);
-			frame.setPreferredSize(new Dimension(Window.W, Window.H));
-			frame.setContentPane(window.getRootPanel());
-			frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
-			frame.pack();
-			frame.setVisible(true);
-		});
-	}
+public State() {
+this(null);
+}
+
+public State(Runnable onConfigComplete) {
+this.onConfigComplete = onConfigComplete;
+SwingUtilities.invokeLater(() -> {
+window = new Window(this);
+frame = (new JFrame(Window.TITLE));
+frame.setSize(Window.W, Window.H);
+frame.setLocationRelativeTo(null);
+frame.setPreferredSize(new Dimension(Window.W, Window.H));
+frame.setContentPane(window.getRootPanel());
+frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+frame.pack();
+frame.setVisible(true);
+});
+}
+
+private void fireConfigComplete() {
+if (onConfigComplete != null) {
+Runnable cb = onConfigComplete;
+onConfigComplete = null;
+cb.run();
+}
+}
 
 	public void killFrame() {
 		try {
@@ -40,9 +54,12 @@ public class State {
 		return state;
 	}
 
-	public void setState(int s) {
-		state = s;
-	}
+public void setState(int s) {
+state = s;
+if (state >= 1) {
+fireConfigComplete();
+}
+}
 
 
 }

--- a/src/Template/src/Walk/Main.java
+++ b/src/Template/src/Walk/Main.java
@@ -6,6 +6,7 @@ import org.dreambot.api.methods.Calculations;
 import org.dreambot.api.script.AbstractScript;
 import org.dreambot.api.script.Category;
 import org.dreambot.api.script.ScriptManifest;
+import java.util.concurrent.CountDownLatch;
 
 @ScriptManifest(category = Category.MISC, name = "tmp.01", author = "Andrew", version = .01)
 
@@ -14,14 +15,17 @@ public class Main extends AbstractScript {
 	private State s;
 
 	@Override
-	public void onStart() { //0th state
-		super.onStart();
-		s = new State();
-		while (s.getState() < 1) {
-			sleep(100);
-		}
-		init();
-	}
+public void onStart() { //0th state
+super.onStart();
+CountDownLatch latch = new CountDownLatch(1);
+s = new State(latch::countDown);
+try {
+latch.await();
+} catch (InterruptedException e) {
+e.printStackTrace();
+}
+init();
+}
 
 	private void init() { //1st state
 	}

--- a/src/WC/src/Handler/State.java
+++ b/src/WC/src/Handler/State.java
@@ -7,24 +7,38 @@ import javax.swing.SwingUtilities;
 
 public class State {
 
-	private JFrame frame;
-	private Window window;
-	private int bankLocation, state = 0, radius;
-	private String tree;
+       private JFrame frame;
+       private Window window;
+       private int bankLocation, state = 0, radius;
+       private String tree;
+       private Runnable onConfigComplete;
 
-	public State() {
-		SwingUtilities.invokeLater(() -> {
-			window = new Window(this);
-			frame = (new JFrame(Window.TITLE));
-			frame.setSize(Window.W, Window.H);
-			frame.setLocationRelativeTo(null);
-			frame.setPreferredSize(new Dimension(Window.W, Window.H));
-			frame.setContentPane(window.getRootPanel());
-			frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
-			frame.pack();
-			frame.setVisible(true);
-		});
-	}
+       public State() {
+               this(null);
+       }
+
+       public State(Runnable onConfigComplete) {
+               this.onConfigComplete = onConfigComplete;
+               SwingUtilities.invokeLater(() -> {
+                       window = new Window(this);
+                       frame = (new JFrame(Window.TITLE));
+                       frame.setSize(Window.W, Window.H);
+                       frame.setLocationRelativeTo(null);
+                       frame.setPreferredSize(new Dimension(Window.W, Window.H));
+                       frame.setContentPane(window.getRootPanel());
+                       frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+                       frame.pack();
+                       frame.setVisible(true);
+               });
+       }
+
+       private void fireConfigComplete() {
+               if (onConfigComplete != null) {
+                       Runnable cb = onConfigComplete;
+                       onConfigComplete = null;
+                       cb.run();
+               }
+       }
 
 	public String getTree() {
 		return tree;
@@ -82,9 +96,12 @@ public class State {
 		return state;
 	}
 
-	public void setState(int s) {
-		state = s;
-	}
+       public void setState(int s) {
+               state = s;
+               if (state >= 1) {
+                       fireConfigComplete();
+               }
+       }
 
 
 }

--- a/src/WC/src/WC/Main.java
+++ b/src/WC/src/WC/Main.java
@@ -9,6 +9,7 @@ import org.dreambot.api.script.AbstractScript;
 import org.dreambot.api.script.Category;
 import org.dreambot.api.script.ScriptManifest;
 import org.dreambot.api.wrappers.interactive.GameObject;
+import java.util.concurrent.CountDownLatch;
 
 @ScriptManifest(category = Category.WOODCUTTING, name = "WC.01", author = "Andrew", version = .01)
 
@@ -56,14 +57,17 @@ public class Main extends AbstractScript {
 	}
 
 	@Override
-	public void onStart() { //0th state
-		super.onStart();
-		s = new State();
-		while (s.getState() < 1) {
-			sleep(100);
-		}
-		init();
-	}
+public void onStart() { //0th state
+super.onStart();
+CountDownLatch latch = new CountDownLatch(1);
+s = new State(latch::countDown);
+try {
+latch.await();
+} catch (InterruptedException e) {
+e.printStackTrace();
+}
+init();
+}
 
 	private void init() { //1st state
 		treeFilter = (tree -> tree.getName().equals(s.getTree()) && cArea.contains(tree));

--- a/src/Walker/src/Handler/State.java
+++ b/src/Walker/src/Handler/State.java
@@ -8,24 +8,38 @@ import javax.swing.SwingUtilities;
 
 public class State {
 
-	private JFrame frame;
-	private Window window;
+private JFrame frame;
+private Window window;
 
-	private int destination = 0, state = 0;
+private int destination = 0, state = 0;
+private Runnable onConfigComplete;
 
-	public State() {
-		SwingUtilities.invokeLater(() -> {
-			window = new Window(this);
-			frame = (new JFrame(Window.TITLE));
-			frame.setSize(Window.W, Window.H);
-			frame.setLocationRelativeTo(null);
-			frame.setPreferredSize(new Dimension(Window.W, Window.H));
-			frame.setContentPane(window.getRootPanel());
-			frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
-			frame.pack();
-			frame.setVisible(true);
-		});
-	}
+public State() {
+this(null);
+}
+
+public State(Runnable onConfigComplete) {
+this.onConfigComplete = onConfigComplete;
+SwingUtilities.invokeLater(() -> {
+window = new Window(this);
+frame = (new JFrame(Window.TITLE));
+frame.setSize(Window.W, Window.H);
+frame.setLocationRelativeTo(null);
+frame.setPreferredSize(new Dimension(Window.W, Window.H));
+frame.setContentPane(window.getRootPanel());
+frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+frame.pack();
+frame.setVisible(true);
+});
+}
+
+private void fireConfigComplete() {
+if (onConfigComplete != null) {
+Runnable cb = onConfigComplete;
+onConfigComplete = null;
+cb.run();
+}
+}
 
 	public void killFrame() {
 		try {
@@ -49,9 +63,12 @@ public class State {
 		return state;
 	}
 
-	public void setState(int s) {
-		state = s;
-	}
+public void setState(int s) {
+state = s;
+if (state >= 1) {
+fireConfigComplete();
+}
+}
 
 
 }

--- a/src/Walker/src/Walk/Main.java
+++ b/src/Walker/src/Walk/Main.java
@@ -9,6 +9,7 @@ import org.dreambot.api.methods.map.Tile;
 import org.dreambot.api.script.AbstractScript;
 import org.dreambot.api.script.Category;
 import org.dreambot.api.script.ScriptManifest;
+import java.util.concurrent.CountDownLatch;
 
 @ScriptManifest(category = Category.MISC, name = "Walker.01", author = "Andrew", version = .01)
 
@@ -21,14 +22,17 @@ public class Main extends AbstractScript {
 
 
 	@Override
-	public void onStart() { //0th state
-		super.onStart();
-		s = new State();
-		while (s.getState() < 1) {
-			sleep(100);
-		}
-		init();
-	}
+public void onStart() { //0th state
+super.onStart();
+CountDownLatch latch = new CountDownLatch(1);
+s = new State(latch::countDown);
+try {
+latch.await();
+} catch (InterruptedException e) {
+e.printStackTrace();
+}
+init();
+}
 
 	private void init() { //1st state
 		generateDestination();


### PR DESCRIPTION
## Summary
- allow all `Handler.State` classes to accept an optional callback that fires when configuration is finished
- replace spin-wait loops in `onStart` with `CountDownLatch` synchronization

## Testing
- `javac -d /tmp/combat_classes src/Combat/src/Handler/State.java src/Combat/src/GUI/Window.java src/Combat/src/GUI/Slider.java`
- `javac -cp /tmp/wc_classes -d /tmp/wc_main_classes src/WC/src/WC/Main.java` *(fails: package org.dreambot.api... does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68abc59106f8832ab4d464027f144715