### PR TITLE
Refactor bank area selection into shared BankHelper

### DIFF
--- a/src/Combat/src/Combat/Main.java
+++ b/src/Combat/src/Combat/Main.java
@@ -1,8 +1,8 @@
 package Combat;
 
 import Handler.State;
+import common.BankHelper;
 import java.util.Random;
-import org.dreambot.api.methods.container.impl.bank.BankLocation;
 import org.dreambot.api.methods.filter.Filter;
 import org.dreambot.api.methods.map.Area;
 import org.dreambot.api.script.AbstractScript;
@@ -36,44 +36,13 @@ public class Main extends AbstractScript {
 
 	private void init() { //1st state
 		kArea = Area.generateArea(s.getFightRadius(), getLocalPlayer().getTile());
-		bankArea = getBankArea();
+		bankArea = BankHelper.resolve(s.getBankLocation(), getLocalPlayer());
 		targetfilter = npc -> npc != null && npc.getName().equals(s.getTarget()) && !npc.isInCombat();
 		target = getNpcs().closest(targetfilter);
 		if (s.isBuryBones()) {
 			s.getLoot().add("Bones");
 		}
 	}
-
-	private Area getBankArea() {
-		BankLocation tmp = BankLocation.getNearest(getLocalPlayer());
-		switch (s.getBankLocation()) {
-			case 0:
-				break;
-			case 1:
-				tmp = BankLocation.DRAYNOR;
-				break;
-			case 2:
-				tmp = BankLocation.FALADOR_EAST;
-				break;
-			case 3:
-				tmp = BankLocation.FALADOR_WEST;
-				break;
-			case 4:
-				tmp = BankLocation.GRAND_EXCHANGE;
-				break;
-			case 5:
-				tmp = BankLocation.LUMBRIDGE;
-				break;
-			case 6:
-				tmp = BankLocation.VARROCK_EAST;
-				break;
-			case 7:
-				tmp = BankLocation.VARROCK_WEST;
-				break;
-		}
-		return tmp.getArea(3);
-	}
-
 	private void checkState() {
 		if (getInventory().isFull()) {
 			if (s.isBuryBones() && getInventory().contains("Bones")) {

--- a/src/WC/src/WC/Main.java
+++ b/src/WC/src/WC/Main.java
@@ -1,8 +1,8 @@
 package WC;
 
 import Handler.State;
+import common.BankHelper;
 import org.dreambot.api.methods.Calculations;
-import org.dreambot.api.methods.container.impl.bank.BankLocation;
 import org.dreambot.api.methods.filter.Filter;
 import org.dreambot.api.methods.map.Area;
 import org.dreambot.api.script.AbstractScript;
@@ -24,37 +24,6 @@ public class Main extends AbstractScript {
 		super.onExit();
 		getMouse().moveMouseOutsideScreen();
 	}
-
-	private Area getBankArea() {
-		BankLocation tmp = BankLocation.getNearest(getLocalPlayer());
-		switch (s.getBankLocation()) {
-			case 0:
-				break;
-			case 1:
-				tmp = BankLocation.DRAYNOR;
-				break;
-			case 2:
-				tmp = BankLocation.FALADOR_EAST;
-				break;
-			case 3:
-				tmp = BankLocation.FALADOR_WEST;
-				break;
-			case 4:
-				tmp = BankLocation.GRAND_EXCHANGE;
-				break;
-			case 5:
-				tmp = BankLocation.LUMBRIDGE;
-				break;
-			case 6:
-				tmp = BankLocation.VARROCK_EAST;
-				break;
-			case 7:
-				tmp = BankLocation.VARROCK_WEST;
-				break;
-		}
-		return tmp.getArea(3);
-	}
-
 	@Override
 	public void onStart() { //0th state
 		super.onStart();
@@ -67,7 +36,7 @@ public class Main extends AbstractScript {
 
 	private void init() { //1st state
 		treeFilter = (tree -> tree.getName().equals(s.getTree()) && cArea.contains(tree));
-		bArea = getBankArea();
+		bArea = BankHelper.resolve(s.getBankLocation(), getLocalPlayer());
 		cArea = getLocalPlayer().getSurroundingArea(s.getRadius());
 	}
 

--- a/src/common/BankHelper.java
+++ b/src/common/BankHelper.java
@@ -1,0 +1,41 @@
+package common;
+
+import org.dreambot.api.methods.container.impl.bank.BankLocation;
+import org.dreambot.api.methods.map.Area;
+import org.dreambot.api.wrappers.interactive.Player;
+
+public final class BankHelper {
+
+    private BankHelper() {
+    }
+
+    public static Area resolve(int bankLocation, Player player) {
+        BankLocation location = BankLocation.getNearest(player);
+        switch (bankLocation) {
+            case 1:
+                location = BankLocation.DRAYNOR;
+                break;
+            case 2:
+                location = BankLocation.FALADOR_EAST;
+                break;
+            case 3:
+                location = BankLocation.FALADOR_WEST;
+                break;
+            case 4:
+                location = BankLocation.GRAND_EXCHANGE;
+                break;
+            case 5:
+                location = BankLocation.LUMBRIDGE;
+                break;
+            case 6:
+                location = BankLocation.VARROCK_EAST;
+                break;
+            case 7:
+                location = BankLocation.VARROCK_WEST;
+                break;
+            default:
+                break;
+        }
+        return location.getArea(3);
+    }
+}


### PR DESCRIPTION
## Summary
- add `BankHelper.resolve` to centralize bank area selection
- use `BankHelper` in Combat and Woodcutting scripts

## Testing
- `./gradlew test` *(fails: No such file or directory)*
- `mvn -q test` *(fails: The goal you specified requires a project to execute but there is no POM in this directory)*

------
https://chatgpt.com/codex/tasks/task_e_68abc59040ac832a90e68479f4775a16