### PR TITLE
Add centralized SuperBot GUI and config

### DIFF
--- a/src/Combat/src/Combat/Main.java
+++ b/src/Combat/src/Combat/Main.java
@@ -10,6 +10,7 @@ import org.dreambot.api.script.Category;
 import org.dreambot.api.script.ScriptManifest;
 import org.dreambot.api.wrappers.interactive.NPC;
 import org.dreambot.api.wrappers.items.GroundItem;
+import SuperBot.SuperBotConfig;
 
 @ScriptManifest(category = Category.COMBAT, name = "Combat.01", author = "Andrew", version = .01)
 
@@ -21,18 +22,23 @@ public class Main extends AbstractScript {
 	private NPC target;
 	private GroundItem lootItem;
 
-	@Override
-	public void onStart() { //0th state
-		super.onStart();
-		s = new State();
-		while (s.getState() < 1) {
+        @Override
+        public void onStart() { //0th state
+                super.onStart();
+                s = new State();
+                while (s.getState() < 1) {
 			sleep(100);
 		}
 		for (String s : s.getLoot()) {
 			log("Looting:" + s);
 		}
-		init();
-	}
+                init();
+        }
+
+        public void onStart(SuperBotConfig.CombatConfig config) {
+                s = new State(config);
+                init();
+        }
 
 	private void init() { //1st state
 		kArea = Area.generateArea(s.getFightRadius(), getLocalPlayer().getTile());

--- a/src/Combat/src/Handler/State.java
+++ b/src/Combat/src/Handler/State.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import java.util.List;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
+import SuperBot.SuperBotConfig;
 
 public class State {
 
@@ -16,11 +17,11 @@ public class State {
 	private boolean buryBones, takeOtherPlayersLoot;
 	private String target, food;
 	private int eatPercentage, bankLocation, foodAmt, fightRadius, state = 0;
-	private List<String> loot;
+        private List<String> loot;
 
-	public State() {
-		SwingUtilities.invokeLater(() -> {
-			window = new Window(this);
+        public State() {
+                SwingUtilities.invokeLater(() -> {
+                        window = new Window(this);
 			setFrame(new JFrame(Window.TITLE));
 			getFrame().setSize(Window.W, Window.H);
 			getFrame().setLocationRelativeTo(null);
@@ -28,9 +29,22 @@ public class State {
 			getFrame().setContentPane(window.getRootPanel());
 			getFrame().setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
 			getFrame().pack();
-			getFrame().setVisible(true);
-		});
-	}
+                        getFrame().setVisible(true);
+                });
+        }
+
+        public State(SuperBotConfig.CombatConfig config) {
+                this.buryBones = config.buryBones;
+                this.takeOtherPlayersLoot = config.takeOtherPlayersLoot;
+                this.target = config.target;
+                this.food = config.food;
+                this.eatPercentage = config.eatPercentage;
+                this.bankLocation = config.bankLocation;
+                this.foodAmt = config.foodAmount;
+                this.fightRadius = config.fightRadius;
+                this.loot = config.loot != null ? config.loot : new ArrayList<>();
+                this.state = 1;
+        }
 
 	public void killFrame() {
 		try {

--- a/src/GoldCrafter/src/Craft/Main.java
+++ b/src/GoldCrafter/src/Craft/Main.java
@@ -11,6 +11,7 @@ import org.dreambot.api.script.AbstractScript;
 import org.dreambot.api.script.Category;
 import org.dreambot.api.script.ScriptManifest;
 import org.dreambot.api.wrappers.widgets.WidgetChild;
+import SuperBot.SuperBotConfig;
 
 @ScriptManifest(category = Category.CRAFTING, name = "Crafting.01", author = "Andrew", version = .01)
 
@@ -24,16 +25,21 @@ public class Main extends AbstractScript {
 	private Tile smeltTile, bankTile;
 	private WidgetChild wig;
 
-	@Override
-	public void onStart() { //0th state
-		super.onStart();
-		s = new State();
-		while (s.getState() < 1) {
-			log("Starting");
-			sleep(200);
-		}
-		init();
-	}
+        @Override
+        public void onStart() { //0th state
+                super.onStart();
+                s = new State();
+                while (s.getState() < 1) {
+                        log("Starting");
+                        sleep(200);
+                }
+                init();
+        }
+
+        public void onStart(SuperBotConfig.GoldCraftingConfig config) {
+                s = new State(config);
+                init();
+        }
 
 	private void init() { //1st state
 		bankArea = getBankArea();

--- a/src/GoldCrafter/src/Handler/State.java
+++ b/src/GoldCrafter/src/Handler/State.java
@@ -5,16 +5,17 @@ import GUI.Window;
 import java.awt.Dimension;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
+import SuperBot.SuperBotConfig;
 
 public class State {
 
 	private JFrame frame;
-	private Window window;
-	private int state = 0, smeltLocation, product;
+        private Window window;
+        private int state = 0, smeltLocation, product;
 
-	public State() {
-		SwingUtilities.invokeLater(() -> {
-			window = new Window(this);
+        public State() {
+                SwingUtilities.invokeLater(() -> {
+                        window = new Window(this);
 			frame = (new JFrame(Window.TITLE));
 			frame.setSize(Window.W, Window.H);
 			frame.setLocationRelativeTo(null);
@@ -22,9 +23,15 @@ public class State {
 			frame.setContentPane(window.getRootPanel());
 			frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
 			frame.pack();
-			frame.setVisible(true);
-		});
-	}
+                        frame.setVisible(true);
+                });
+        }
+
+        public State(SuperBotConfig.GoldCraftingConfig config) {
+                this.smeltLocation = config.smeltLocation;
+                this.product = config.product;
+                this.state = 1;
+        }
 
 	public void killFrame() {
 		try {

--- a/src/Miner/src/Main.java
+++ b/src/Miner/src/Main.java
@@ -1,0 +1,26 @@
+package Miner;
+
+import org.dreambot.api.script.AbstractScript;
+import org.dreambot.api.script.Category;
+import org.dreambot.api.script.ScriptManifest;
+import SuperBot.SuperBotConfig;
+
+@ScriptManifest(category = Category.MINING, name = "Miner", author = "Andrew", version = 0.01)
+public class Main extends AbstractScript {
+
+    private SuperBotConfig.MiningConfig config;
+
+    @Override
+    public void onStart() {
+        // default start does nothing
+    }
+
+    public void onStart(SuperBotConfig.MiningConfig config) {
+        this.config = config;
+    }
+
+    @Override
+    public int onLoop() {
+        return 1000;
+    }
+}

--- a/src/SuperBot/src/GUI/Window.java
+++ b/src/SuperBot/src/GUI/Window.java
@@ -1,0 +1,66 @@
+package SuperBot.GUI;
+
+import SuperBot.SuperBotConfig;
+import javax.swing.*;
+import java.awt.*;
+
+public class Window extends JFrame {
+    public static final int W = 400, H = 300;
+
+    public Window(SuperBotConfig config) {
+        super("Super Bot");
+        setSize(W, H);
+        setLocationRelativeTo(null);
+        setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+
+        JTabbedPane tabs = new JTabbedPane();
+
+        // Combat tab
+        JPanel combatPanel = new JPanel();
+        JTextField targetField = new JTextField(10);
+        JTextField foodField = new JTextField(10);
+        combatPanel.add(new JLabel("Target:"));
+        combatPanel.add(targetField);
+        combatPanel.add(new JLabel("Food:"));
+        combatPanel.add(foodField);
+        tabs.add("Combat", combatPanel);
+
+        // Woodcutting tab
+        JPanel wcPanel = new JPanel();
+        JTextField treeField = new JTextField(10);
+        wcPanel.add(new JLabel("Tree:"));
+        wcPanel.add(treeField);
+        tabs.add("Woodcutting", wcPanel);
+
+        // Mining tab
+        JPanel miningPanel = new JPanel();
+        JCheckBox dropCheck = new JCheckBox("Drop ores");
+        miningPanel.add(dropCheck);
+        tabs.add("Mining", miningPanel);
+
+        // Gold crafting tab
+        JPanel goldPanel = new JPanel();
+        JTextField productField = new JTextField(10);
+        goldPanel.add(new JLabel("Product ID:"));
+        goldPanel.add(productField);
+        tabs.add("GoldCrafting", goldPanel);
+
+        JButton startButton = new JButton("Start");
+        startButton.addActionListener(e -> {
+            config.combat.target = targetField.getText();
+            config.combat.food = foodField.getText();
+            config.woodcutting.tree = treeField.getText();
+            config.mining.drop = dropCheck.isSelected();
+            try {
+                config.goldCrafting.product = Integer.parseInt(productField.getText());
+            } catch (NumberFormatException ex) {
+                config.goldCrafting.product = 0;
+            }
+            config.start = true;
+            dispose();
+        });
+
+        add(tabs, BorderLayout.CENTER);
+        add(startButton, BorderLayout.SOUTH);
+    }
+}

--- a/src/SuperBot/src/Main.java
+++ b/src/SuperBot/src/Main.java
@@ -1,0 +1,32 @@
+package SuperBot;
+
+import SuperBot.GUI.Window;
+import org.dreambot.api.script.AbstractScript;
+import org.dreambot.api.script.Category;
+import org.dreambot.api.script.ScriptManifest;
+
+@ScriptManifest(category = Category.MISC, name = "SuperBot", author = "Andrew", version = 0.01)
+public class Main extends AbstractScript {
+
+    private SuperBotConfig config = new SuperBotConfig();
+
+    @Override
+    public void onStart() {
+        Window window = new Window(config);
+        window.setVisible(true);
+        while (window.isDisplayable() && !config.start) {
+            sleep(100);
+        }
+        if (config.start) {
+            new Combat.Main().onStart(config.combat);
+            new WC.Main().onStart(config.woodcutting);
+            new Miner.Main().onStart(config.mining);
+            new Craft.Main().onStart(config.goldCrafting);
+        }
+    }
+
+    @Override
+    public int onLoop() {
+        return 1000;
+    }
+}

--- a/src/SuperBot/src/SuperBotConfig.java
+++ b/src/SuperBot/src/SuperBotConfig.java
@@ -1,0 +1,42 @@
+package SuperBot;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SuperBotConfig {
+
+    public CombatConfig combat = new CombatConfig();
+    public WoodcuttingConfig woodcutting = new WoodcuttingConfig();
+    public MiningConfig mining = new MiningConfig();
+    public GoldCraftingConfig goldCrafting = new GoldCraftingConfig();
+    public boolean start = false;
+
+    public static class CombatConfig {
+        public String target = "";
+        public String food = "";
+        public int foodAmount = 0;
+        public int fightRadius = 5;
+        public int bankLocation = 0;
+        public int eatPercentage = 50;
+        public boolean buryBones = false;
+        public boolean takeOtherPlayersLoot = false;
+        public List<String> loot = new ArrayList<>();
+    }
+
+    public static class WoodcuttingConfig {
+        public String tree = "";
+        public int radius = 5;
+        public int bankLocation = 0;
+    }
+
+    public static class MiningConfig {
+        public int radius = 5;
+        public int bankLocation = 0;
+        public boolean drop = false;
+    }
+
+    public static class GoldCraftingConfig {
+        public int smeltLocation = 0;
+        public int product = 0;
+    }
+}

--- a/src/WC/src/Handler/State.java
+++ b/src/WC/src/Handler/State.java
@@ -4,17 +4,18 @@ import GUI.Window;
 import java.awt.Dimension;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
+import SuperBot.SuperBotConfig;
 
 public class State {
 
 	private JFrame frame;
-	private Window window;
-	private int bankLocation, state = 0, radius;
-	private String tree;
+        private Window window;
+        private int bankLocation, state = 0, radius;
+        private String tree;
 
-	public State() {
-		SwingUtilities.invokeLater(() -> {
-			window = new Window(this);
+        public State() {
+                SwingUtilities.invokeLater(() -> {
+                        window = new Window(this);
 			frame = (new JFrame(Window.TITLE));
 			frame.setSize(Window.W, Window.H);
 			frame.setLocationRelativeTo(null);
@@ -22,9 +23,16 @@ public class State {
 			frame.setContentPane(window.getRootPanel());
 			frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
 			frame.pack();
-			frame.setVisible(true);
-		});
-	}
+                        frame.setVisible(true);
+                });
+        }
+
+        public State(SuperBotConfig.WoodcuttingConfig config) {
+                this.bankLocation = config.bankLocation;
+                this.radius = config.radius;
+                this.tree = config.tree;
+                this.state = 1;
+        }
 
 	public String getTree() {
 		return tree;

--- a/src/WC/src/WC/Main.java
+++ b/src/WC/src/WC/Main.java
@@ -9,6 +9,7 @@ import org.dreambot.api.script.AbstractScript;
 import org.dreambot.api.script.Category;
 import org.dreambot.api.script.ScriptManifest;
 import org.dreambot.api.wrappers.interactive.GameObject;
+import SuperBot.SuperBotConfig;
 
 @ScriptManifest(category = Category.WOODCUTTING, name = "WC.01", author = "Andrew", version = .01)
 
@@ -55,15 +56,20 @@ public class Main extends AbstractScript {
 		return tmp.getArea(3);
 	}
 
-	@Override
-	public void onStart() { //0th state
-		super.onStart();
-		s = new State();
-		while (s.getState() < 1) {
-			sleep(100);
-		}
-		init();
-	}
+        @Override
+        public void onStart() { //0th state
+                super.onStart();
+                s = new State();
+                while (s.getState() < 1) {
+                        sleep(100);
+                }
+                init();
+        }
+
+        public void onStart(SuperBotConfig.WoodcuttingConfig config) {
+                s = new State(config);
+                init();
+        }
 
 	private void init() { //1st state
 		treeFilter = (tree -> tree.getName().equals(s.getTree()) && cArea.contains(tree));


### PR DESCRIPTION
## Summary
- Add `SuperBot` module with a shared `SuperBotConfig` to hold user selections
- Build a `JFrame` containing tabs for Combat, Woodcutting, Mining, and GoldCrafting
- Expose new `onStart` overloads in task scripts to accept their specific config slices

## Testing
- `./gradlew test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68abc308de24832aa6af0c233036eb6e