### PR TITLE
Add BotTask interface for shared lifecycle

### DIFF
--- a/src/superbot/BotTask.java
+++ b/src/superbot/BotTask.java
@@ -1,0 +1,32 @@
+package superbot;
+
+/**
+ * Represents a generic task in a bot's lifecycle.
+ */
+public interface BotTask {
+    /**
+     * Called once when the task is started.
+     */
+    default void onStart() {}
+
+    /**
+     * Called repeatedly while the task is running.
+     *
+     * @return the delay in milliseconds before the next loop.
+     */
+    int onLoop();
+
+    /**
+     * Called when the task is exiting.
+     */
+    default void onExit() {}
+
+    /**
+     * Optional human-readable name for logging.
+     *
+     * @return the task's name.
+     */
+    default String getName() {
+        return getClass().getSimpleName();
+    }
+}


### PR DESCRIPTION
## Summary
- add shared `BotTask` interface with onStart, onLoop, onExit hooks
- provide optional `getName` method for task logging

## Testing
- `javac src/superbot/BotTask.java`


------
https://chatgpt.com/codex/tasks/task_e_68abc30583c0832a91ad3bd85e2c2a80