### PR TITLE
refactor: introduce enum states for scripts

### DIFF
--- a/src/Combat/src/Combat/Main.java
+++ b/src/Combat/src/Combat/Main.java
@@ -1,6 +1,5 @@
 package Combat;
 
-import Handler.State;
 import java.util.Random;
 import org.dreambot.api.methods.container.impl.bank.BankLocation;
 import org.dreambot.api.methods.filter.Filter;
@@ -14,23 +13,33 @@ import org.dreambot.api.wrappers.items.GroundItem;
 @ScriptManifest(category = Category.COMBAT, name = "Combat.01", author = "Andrew", version = .01)
 
 public class Main extends AbstractScript {
+        public enum State {
+                SETUP,
+                INIT,
+                ATTACK,
+                MOVE_TO_BANK,
+                BANK,
+                LOOT,
+                RETURN,
+                ANTIBAN
+        }
 
-	private Filter<NPC> targetfilter;
-	private Area kArea, bankArea;
-	private State s;
-	private NPC target;
-	private GroundItem lootItem;
+        private Filter<NPC> targetfilter;
+        private Area kArea, bankArea;
+        private Handler.State s;
+        private NPC target;
+        private GroundItem lootItem;
 
 	@Override
 	public void onStart() { //0th state
 		super.onStart();
-		s = new State();
-		while (s.getState() < 1) {
-			sleep(100);
-		}
-		for (String s : s.getLoot()) {
-			log("Looting:" + s);
-		}
+                s = new Handler.State();
+                while (s.getState() == State.SETUP) {
+                        sleep(100);
+                }
+                for (String loot : s.getLoot()) {
+                        log("Looting:" + loot);
+                }
 		init();
 	}
 
@@ -46,31 +55,33 @@ public class Main extends AbstractScript {
 
 	private Area getBankArea() {
 		BankLocation tmp = BankLocation.getNearest(getLocalPlayer());
-		switch (s.getBankLocation()) {
-			case 0:
-				break;
-			case 1:
-				tmp = BankLocation.DRAYNOR;
-				break;
-			case 2:
-				tmp = BankLocation.FALADOR_EAST;
-				break;
-			case 3:
-				tmp = BankLocation.FALADOR_WEST;
-				break;
-			case 4:
-				tmp = BankLocation.GRAND_EXCHANGE;
-				break;
-			case 5:
-				tmp = BankLocation.LUMBRIDGE;
-				break;
-			case 6:
-				tmp = BankLocation.VARROCK_EAST;
-				break;
-			case 7:
-				tmp = BankLocation.VARROCK_WEST;
-				break;
-		}
+                switch (s.getBankLocation()) {
+                        case 0:
+                                break;
+                        case 1:
+                                tmp = BankLocation.DRAYNOR;
+                                break;
+                        case 2:
+                                tmp = BankLocation.FALADOR_EAST;
+                                break;
+                        case 3:
+                                tmp = BankLocation.FALADOR_WEST;
+                                break;
+                        case 4:
+                                tmp = BankLocation.GRAND_EXCHANGE;
+                                break;
+                        case 5:
+                                tmp = BankLocation.LUMBRIDGE;
+                                break;
+                        case 6:
+                                tmp = BankLocation.VARROCK_EAST;
+                                break;
+                        case 7:
+                                tmp = BankLocation.VARROCK_WEST;
+                                break;
+                        default:
+                                break;
+                }
 		return tmp.getArea(3);
 	}
 
@@ -79,26 +90,26 @@ public class Main extends AbstractScript {
 			if (s.isBuryBones() && getInventory().contains("Bones")) {
 				getInventory().all(item -> item.getName().equals("Bones")).stream().forEach(item -> item.interact("Bury"));
 			} else if (bankArea.contains(getLocalPlayer())) {
-				s.setState(4);  //Bank
-			} else {
-				s.setState(3);  //Walk to Bank
-			}
-		} else {
-			if (kArea.contains(getLocalPlayer())) {
-				lootItem = getGroundItems().closest(
-						groundItem -> groundItem != null && groundItem.exists() && groundItem.getName() != null && (target
-								.getSurroundingArea(1)).contains(groundItem) && s.getLoot().stream()
-								.anyMatch(lootStr -> lootStr.equals(groundItem.getName())));
-				if (lootItem != null && !getLocalPlayer().isInCombat()) {
-					s.setState(5);  //Loot
-				} else {
-					s.setState(2);  //Attack
-				}
-			} else {
-				s.setState(6);  //Walk back
-			}
-		}
-	}
+                                s.setState(State.BANK);  //Bank
+                        } else {
+                                s.setState(State.MOVE_TO_BANK);  //Walk to Bank
+                        }
+                } else {
+                        if (kArea.contains(getLocalPlayer())) {
+                                lootItem = getGroundItems().closest(
+                                                groundItem -> groundItem != null && groundItem.exists() && groundItem.getName() != null && (target
+                                                                .getSurroundingArea(1)).contains(groundItem) && s.getLoot().stream()
+                                                                .anyMatch(lootStr -> lootStr.equals(groundItem.getName())));
+                                if (lootItem != null && !getLocalPlayer().isInCombat()) {
+                                        s.setState(State.LOOT);  //Loot
+                                } else {
+                                        s.setState(State.ATTACK);  //Attack
+                                }
+                        } else {
+                                s.setState(State.RETURN);  //Walk back
+                        }
+                }
+        }
 
 	private int bank() {  //4th state
 		if (getBank().isOpen()) {
@@ -174,26 +185,28 @@ public class Main extends AbstractScript {
 		5 - Loot
 		6 - Return
 		*/
-		switch (s.getState()) {
-			case 2:
-				return checkCombat();
-			case 3:
-				moveToBank();
-				break;
-			case 4:
-				return bank();
-			case 5:
-				loot();
-				break;
-			case 6:
-				walkBack();
-				break;
-			case 7:
-				antiBan();
-				break;
-		}
+                switch (s.getState()) {
+                        case ATTACK:
+                                return checkCombat();
+                        case MOVE_TO_BANK:
+                                moveToBank();
+                                break;
+                        case BANK:
+                                return bank();
+                        case LOOT:
+                                loot();
+                                break;
+                        case RETURN:
+                                walkBack();
+                                break;
+                        case ANTIBAN:
+                                antiBan();
+                                break;
+                        default:
+                                break;
+                }
 
-		//DEFAULT:
-		return ((int) (Math.random() * 200));
-	}
+                //DEFAULT:
+                return ((int) (Math.random() * 200));
+        }
 }

--- a/src/Combat/src/GUI/Window.java
+++ b/src/Combat/src/GUI/Window.java
@@ -42,10 +42,10 @@ public class Window extends JFrame {
 			s.setTakeOtherPlayersLoot(takeAllCheckBox.isSelected());
 			s.setBankLocation(bankLocation.getSelectedIndex());
 			s.setEatPercentage(eatSlider.getValue());
-			s.setState(1);
-			s.killFrame();
-		});
-	}
+                        s.setState(Combat.Main.State.INIT);
+                        s.killFrame();
+                });
+        }
 
 	public JPanel getRootPanel() {
 		return RootPanel;

--- a/src/Combat/src/Handler/State.java
+++ b/src/Combat/src/Handler/State.java
@@ -11,12 +11,13 @@ import javax.swing.SwingUtilities;
 
 public class State {
 
-	private JFrame frame;
-	private Window window;
-	private boolean buryBones, takeOtherPlayersLoot;
-	private String target, food;
-	private int eatPercentage, bankLocation, foodAmt, fightRadius, state = 0;
-	private List<String> loot;
+        private JFrame frame;
+        private Window window;
+        private boolean buryBones, takeOtherPlayersLoot;
+        private String target, food;
+        private int eatPercentage, bankLocation, foodAmt, fightRadius;
+        private Combat.Main.State state = Combat.Main.State.SETUP;
+        private List<String> loot;
 
 	public State() {
 		SwingUtilities.invokeLater(() -> {
@@ -71,13 +72,13 @@ public class State {
 		}
 	}
 
-	public int getState() {
-		return state;
-	}
+        public Combat.Main.State getState() {
+                return state;
+        }
 
-	public void setState(int s) {
-		state = s;
-	}
+        public void setState(Combat.Main.State s) {
+                state = s;
+        }
 
 	public String getTarget() {
 		return target;

--- a/src/GoldCrafter/src/Craft/Main.java
+++ b/src/GoldCrafter/src/Craft/Main.java
@@ -1,6 +1,5 @@
 package Craft;
 
-import Handler.State;
 import org.dreambot.api.methods.Calculations;
 import org.dreambot.api.methods.container.impl.bank.BankLocation;
 import org.dreambot.api.methods.map.Area;
@@ -16,23 +15,32 @@ import org.dreambot.api.wrappers.widgets.WidgetChild;
 
 public class Main extends AbstractScript {
 
-	private final int FURNACE_ID = 24009, GOLD_BAR_ID = 2357;
-	private Product jewelery;
+        public enum State {
+                SETUP,
+                INIT,
+                SMELT,
+                MOVE_TO_SMELT,
+                MOVE_TO_BANK,
+                BANK
+        }
 
-	private State s;
-	private Area bankArea, smeltArea;
-	private Tile smeltTile, bankTile;
-	private WidgetChild wig;
+        private final int FURNACE_ID = 24009, GOLD_BAR_ID = 2357;
+        private Product jewelery;
+
+        private Handler.State s;
+        private Area bankArea, smeltArea;
+        private Tile smeltTile, bankTile;
+        private WidgetChild wig;
 
 	@Override
 	public void onStart() { //0th state
 		super.onStart();
-		s = new State();
-		while (s.getState() < 1) {
-			log("Starting");
-			sleep(200);
-		}
-		init();
+                s = new Handler.State();
+                while (s.getState() == State.SETUP) {
+                        log("Starting");
+                        sleep(200);
+                }
+                init();
 	}
 
 	private void init() { //1st state
@@ -48,35 +56,39 @@ public class Main extends AbstractScript {
 	}
 
 	private Area getSmeltArea() {
-		switch (s.getSmeltLocation()) {
-			case 0:
-				return new Area(3274, 3184, 3279, 3188, 0);
-			case 1:
-				return new Tile(2973, 3370, 0).getArea(2);
-		}
-		return null;
+                switch (s.getSmeltLocation()) {
+                        case 0:
+                                return new Area(3274, 3184, 3279, 3188, 0);
+                        case 1:
+                                return new Tile(2973, 3370, 0).getArea(2);
+                        default:
+                                return null;
+                }
 	}
 
 	private Product getJewelery() {
-		switch (s.getProduct()) {
-			case 0:
-				return Product.AMULET;
-			case 1:
-				return Product.NECKLACE;
-			case 2:
-				return Product.RING;
-		}
-		return null;
+                switch (s.getProduct()) {
+                        case 0:
+                                return Product.AMULET;
+                        case 1:
+                                return Product.NECKLACE;
+                        case 2:
+                                return Product.RING;
+                        default:
+                                return null;
+                }
 	}
 
 	private Area getBankArea() {
-		switch (s.getSmeltLocation()) {
-			case 0:   //Al Kharid bank
-				return new Area(3269, 3166, 3271, 3169, 0);
-			case 1:  //:
-				break;
-		}
-		return BankLocation.getNearest(getLocalPlayer()).getArea(3);
+                switch (s.getSmeltLocation()) {
+                        case 0:   //Al Kharid bank
+                                return new Area(3269, 3166, 3271, 3169, 0);
+                        case 1:  //:
+                                break;
+                        default:
+                                break;
+                }
+                return BankLocation.getNearest(getLocalPlayer()).getArea(3);
 	}
 
 	private Tile getBankTile() {
@@ -181,18 +193,18 @@ public class Main extends AbstractScript {
 
 	private void checkState() {
 		if (getInventory().contains(GOLD_BAR_ID)) {
-			if (smeltArea.getNearestTile(getLocalPlayer()).distance() > Calculations.random(4, 11)) {
-				s.setState(3);
-			} else {
-				s.setState(2);
-			}
-		} else {
-			if (bankArea.getNearestTile(getLocalPlayer()).distance() > Calculations.random(4, 11)) {
-				s.setState(4);
-			} else {
-				s.setState(5);
-			}
-		}
+                        if (smeltArea.getNearestTile(getLocalPlayer()).distance() > Calculations.random(4, 11)) {
+                                s.setState(State.MOVE_TO_SMELT);
+                        } else {
+                                s.setState(State.SMELT);
+                        }
+                } else {
+                        if (bankArea.getNearestTile(getLocalPlayer()).distance() > Calculations.random(4, 11)) {
+                                s.setState(State.MOVE_TO_BANK);
+                        } else {
+                                s.setState(State.BANK);
+                        }
+                }
 		/*
 		3 - move to smelt
 		2 - smelt
@@ -204,22 +216,24 @@ public class Main extends AbstractScript {
 	@Override
 	public int onLoop() {
 		checkState();
-		switch (s.getState()) {
-			case 2:
-				smelt();
-				break;
-			case 3:
-				moveToSmelt();
-				break;
-			case 4:
-				moveToBank();
-				break;
-			case 5:
-				bank();
-				break;
-		}
-		return Calculations.random(50, 100);
-	}
+                switch (s.getState()) {
+                        case SMELT:
+                                smelt();
+                                break;
+                        case MOVE_TO_SMELT:
+                                moveToSmelt();
+                                break;
+                        case MOVE_TO_BANK:
+                                moveToBank();
+                                break;
+                        case BANK:
+                                bank();
+                                break;
+                        default:
+                                break;
+                }
+                return Calculations.random(50, 100);
+        }
 
 	private void logout() {
 		log("Exiting");

--- a/src/GoldCrafter/src/Handler/State.java
+++ b/src/GoldCrafter/src/Handler/State.java
@@ -8,9 +8,10 @@ import javax.swing.SwingUtilities;
 
 public class State {
 
-	private JFrame frame;
-	private Window window;
-	private int state = 0, smeltLocation, product;
+        private JFrame frame;
+        private Window window;
+        private Craft.Main.State state = Craft.Main.State.SETUP;
+        private int smeltLocation, product;
 
 	public State() {
 		SwingUtilities.invokeLater(() -> {
@@ -34,8 +35,8 @@ public class State {
 		} catch (Exception woeIsMe) {
 			woeIsMe.printStackTrace();
 		}
-		setState(1);
-	}
+                setState(Craft.Main.State.INIT);
+        }
 
 	public int getSmeltLocation() {
 		return smeltLocation;
@@ -45,13 +46,13 @@ public class State {
 		this.smeltLocation = smeltLocation;
 	}
 
-	public int getState() {
-		return state;
-	}
+        public Craft.Main.State getState() {
+                return state;
+        }
 
-	public void setState(int s) {
-		state = s;
-	}
+        public void setState(Craft.Main.State s) {
+                state = s;
+        }
 
 
 	public int getProduct() {

--- a/src/WC/src/GUI/Window.java
+++ b/src/WC/src/GUI/Window.java
@@ -26,7 +26,7 @@ public class Window extends JFrame {
 	public Window(State s) {
 		this.s = s;
 		startButton.addActionListener(actionEvent -> {
-			s.setState(1);
+                        s.setState(WC.Main.State.INIT);
 			s.setBankLocation(walkLocation.getSelectedIndex());
 			s.setTree(logType.getSelectedIndex());
 			s.setRadius(radius.getText());

--- a/src/WC/src/Handler/State.java
+++ b/src/WC/src/Handler/State.java
@@ -7,10 +7,11 @@ import javax.swing.SwingUtilities;
 
 public class State {
 
-	private JFrame frame;
-	private Window window;
-	private int bankLocation, state = 0, radius;
-	private String tree;
+        private JFrame frame;
+        private Window window;
+        private int bankLocation, radius;
+        private WC.Main.State state = WC.Main.State.SETUP;
+        private String tree;
 
 	public State() {
 		SwingUtilities.invokeLater(() -> {
@@ -31,20 +32,23 @@ public class State {
 	}
 
 	public void setTree(int l) {
-		switch (l) {
-			case 0:
-				tree = "Tree";
-				break;
-			case 1:
-				tree = "Oak Tree";
-				break;
-			case 2:
-				tree = "Willow Tree";
-				break;
-			case 3:
-				tree = "Yew Tree";
-				break;
-		}
+                switch (l) {
+                        case 0:
+                                tree = "Tree";
+                                break;
+                        case 1:
+                                tree = "Oak Tree";
+                                break;
+                        case 2:
+                                tree = "Willow Tree";
+                                break;
+                        case 3:
+                                tree = "Yew Tree";
+                                break;
+                        default:
+                                tree = "Tree";
+                                break;
+                }
 	}
 
 	public int getRadius() {
@@ -78,13 +82,13 @@ public class State {
 		}
 	}
 
-	public int getState() {
-		return state;
-	}
+        public WC.Main.State getState() {
+                return state;
+        }
 
-	public void setState(int s) {
-		state = s;
-	}
+        public void setState(WC.Main.State s) {
+                state = s;
+        }
 
 
 }

--- a/src/WC/src/WC/Main.java
+++ b/src/WC/src/WC/Main.java
@@ -1,6 +1,5 @@
 package WC;
 
-import Handler.State;
 import org.dreambot.api.methods.Calculations;
 import org.dreambot.api.methods.container.impl.bank.BankLocation;
 import org.dreambot.api.methods.filter.Filter;
@@ -14,10 +13,19 @@ import org.dreambot.api.wrappers.interactive.GameObject;
 
 public class Main extends AbstractScript {
 
-	private State s;
-	private Area bArea, cArea;
-	private GameObject curTree;
-	private Filter<GameObject> treeFilter;
+        public enum State {
+                SETUP,
+                INIT,
+                CUT,
+                MOVE_TO_BANK,
+                BANK,
+                WALK_BACK
+        }
+
+        private Handler.State s;
+        private Area bArea, cArea;
+        private GameObject curTree;
+        private Filter<GameObject> treeFilter;
 
 	@Override
 	public void onExit() {
@@ -27,42 +35,44 @@ public class Main extends AbstractScript {
 
 	private Area getBankArea() {
 		BankLocation tmp = BankLocation.getNearest(getLocalPlayer());
-		switch (s.getBankLocation()) {
-			case 0:
-				break;
-			case 1:
-				tmp = BankLocation.DRAYNOR;
-				break;
-			case 2:
-				tmp = BankLocation.FALADOR_EAST;
-				break;
-			case 3:
-				tmp = BankLocation.FALADOR_WEST;
-				break;
-			case 4:
-				tmp = BankLocation.GRAND_EXCHANGE;
-				break;
-			case 5:
-				tmp = BankLocation.LUMBRIDGE;
-				break;
-			case 6:
-				tmp = BankLocation.VARROCK_EAST;
-				break;
-			case 7:
-				tmp = BankLocation.VARROCK_WEST;
-				break;
-		}
+                switch (s.getBankLocation()) {
+                        case 0:
+                                break;
+                        case 1:
+                                tmp = BankLocation.DRAYNOR;
+                                break;
+                        case 2:
+                                tmp = BankLocation.FALADOR_EAST;
+                                break;
+                        case 3:
+                                tmp = BankLocation.FALADOR_WEST;
+                                break;
+                        case 4:
+                                tmp = BankLocation.GRAND_EXCHANGE;
+                                break;
+                        case 5:
+                                tmp = BankLocation.LUMBRIDGE;
+                                break;
+                        case 6:
+                                tmp = BankLocation.VARROCK_EAST;
+                                break;
+                        case 7:
+                                tmp = BankLocation.VARROCK_WEST;
+                                break;
+                        default:
+                                break;
+                }
 		return tmp.getArea(3);
 	}
 
 	@Override
 	public void onStart() { //0th state
 		super.onStart();
-		s = new State();
-		while (s.getState() < 1) {
-			sleep(100);
-		}
-		init();
+                s = new Handler.State();
+                while (s.getState() == State.SETUP) {
+                        sleep(100);
+                }
+                init();
 	}
 
 	private void init() { //1st state
@@ -74,18 +84,18 @@ public class Main extends AbstractScript {
 	private void checkState() {
 		if (getInventory().isFull()) {
 			if (bArea.contains(getLocalPlayer())) { //Bank
-				s.setState(4);
-			} else {  //Move to bank
-				s.setState(3);
-			}
-		} else if (!cArea.contains(getLocalPlayer())) {
-			s.setState(5);
-		} else {
-			if (!getLocalPlayer().isAnimating()) {
-				s.setState(2);  //Find next tree to chop
-			}
-		}
-	}
+                                s.setState(State.BANK);
+                        } else {  //Move to bank
+                                s.setState(State.MOVE_TO_BANK);
+                        }
+                } else if (!cArea.contains(getLocalPlayer())) {
+                        s.setState(State.WALK_BACK);
+                } else {
+                        if (!getLocalPlayer().isAnimating()) {
+                                s.setState(State.CUT);  //Find next tree to chop
+                        }
+                }
+        }
 
 
 	private void moveToBank() {  //////////////3rd state////////////////
@@ -124,23 +134,25 @@ public class Main extends AbstractScript {
 	@Override
 	public int onLoop() {
 		checkState();
-		switch (s.getState()) {
-			case 2: //Cut
-				cut();
-				break;
-			case 3:  //Move to bank
-				moveToBank();
-				break;
-			case 4:
-				bank();
-				break;
-			case 5: //Move back
-				walkBack();
-				break;
-		}
+                switch (s.getState()) {
+                        case CUT: //Cut
+                                cut();
+                                break;
+                        case MOVE_TO_BANK:  //Move to bank
+                                moveToBank();
+                                break;
+                        case BANK:
+                                bank();
+                                break;
+                        case WALK_BACK: //Move back
+                                walkBack();
+                                break;
+                        default:
+                                break;
+                }
 
-		//RUN EVERY SECOND-ISH
-		return Calculations.random(200, 500);
-	}
+                //RUN EVERY SECOND-ISH
+                return Calculations.random(200, 500);
+        }
 }
 


### PR DESCRIPTION
## Summary
- replace numeric script states with descriptive `State` enums in Combat, Woodcutting, and GoldCrafter scripts
- update handlers and GUIs to use enum-based state management
- add default branches to all switch statements for safer control flow

## Testing
- `javac src/Combat/src/Combat/Main.java` *(fails: package org.dreambot.api... does not exist)*
- `javac src/WC/src/WC/Main.java` *(fails: package org.dreambot.api... does not exist)*
- `javac src/GoldCrafter/src/Craft/Main.java` *(fails: package org.dreambot.api... does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68ac84203f50832abb29c9cf0e2abcb0