### PR TITLE
Add task management framework

### DIFF
--- a/src/Combat/src/Combat/Main.java
+++ b/src/Combat/src/Combat/Main.java
@@ -6,14 +6,11 @@ import org.dreambot.api.methods.container.impl.bank.BankLocation;
 import org.dreambot.api.methods.filter.Filter;
 import org.dreambot.api.methods.map.Area;
 import org.dreambot.api.script.AbstractScript;
-import org.dreambot.api.script.Category;
-import org.dreambot.api.script.ScriptManifest;
 import org.dreambot.api.wrappers.interactive.NPC;
 import org.dreambot.api.wrappers.items.GroundItem;
+import task.Task;
 
-@ScriptManifest(category = Category.COMBAT, name = "Combat.01", author = "Andrew", version = .01)
-
-public class Main extends AbstractScript {
+public class Main extends AbstractScript implements Task {
 
 	private Filter<NPC> targetfilter;
 	private Area kArea, bankArea;
@@ -27,7 +24,7 @@ public class Main extends AbstractScript {
 		s = new State();
 		while (s.getState() < 1) {
 			sleep(100);
-		}
+        }
 		for (String s : s.getLoot()) {
 			log("Looting:" + s);
 		}
@@ -164,7 +161,7 @@ public class Main extends AbstractScript {
 	}
 
 	@Override
-	public int onLoop() {
+        public int onLoop() {
 		checkState();
 		/* Key
 		0/1 - GUI StartUp
@@ -193,7 +190,17 @@ public class Main extends AbstractScript {
 				break;
 		}
 
-		//DEFAULT:
-		return ((int) (Math.random() * 200));
-	}
+                //DEFAULT:
+                return ((int) (Math.random() * 200));
+        }
+
+        @Override
+        public boolean isComplete() {
+                return false;
+        }
+
+        @Override
+        public int execute() {
+                return onLoop();
+        }
 }

--- a/src/GoldCrafter/src/Craft/Main.java
+++ b/src/GoldCrafter/src/Craft/Main.java
@@ -8,13 +8,10 @@ import org.dreambot.api.methods.map.Tile;
 import org.dreambot.api.methods.skills.Skill;
 import org.dreambot.api.methods.tabs.Tab;
 import org.dreambot.api.script.AbstractScript;
-import org.dreambot.api.script.Category;
-import org.dreambot.api.script.ScriptManifest;
 import org.dreambot.api.wrappers.widgets.WidgetChild;
+import task.Task;
 
-@ScriptManifest(category = Category.CRAFTING, name = "Crafting.01", author = "Andrew", version = .01)
-
-public class Main extends AbstractScript {
+public class Main extends AbstractScript implements Task {
 
 	private final int FURNACE_ID = 24009, GOLD_BAR_ID = 2357;
 	private Product jewelery;
@@ -202,9 +199,9 @@ public class Main extends AbstractScript {
 	}
 
 	@Override
-	public int onLoop() {
-		checkState();
-		switch (s.getState()) {
+        public int onLoop() {
+                checkState();
+                switch (s.getState()) {
 			case 2:
 				smelt();
 				break;
@@ -218,8 +215,18 @@ public class Main extends AbstractScript {
 				bank();
 				break;
 		}
-		return Calculations.random(50, 100);
-	}
+                return Calculations.random(50, 100);
+        }
+
+        @Override
+        public boolean isComplete() {
+                return false;
+        }
+
+        @Override
+        public int execute() {
+                return onLoop();
+        }
 
 	private void logout() {
 		log("Exiting");

--- a/src/Miner/src/nezz/dreambot/scriptmain/powerminer/Miner.java
+++ b/src/Miner/src/nezz/dreambot/scriptmain/powerminer/Miner.java
@@ -13,15 +13,13 @@ import org.dreambot.api.methods.container.impl.bank.Bank;
 import org.dreambot.api.methods.map.Tile;
 import org.dreambot.api.methods.skills.Skill;
 import org.dreambot.api.script.AbstractScript;
-import org.dreambot.api.script.Category;
-import org.dreambot.api.script.ScriptManifest;
+import task.Task;
 import org.dreambot.api.utilities.Timer;
 import org.dreambot.api.wrappers.interactive.GameObject;
 import org.dreambot.api.wrappers.interactive.Player;
 import org.dreambot.api.wrappers.items.Item;
 
-@ScriptManifest(author = "Andrew", description = "Power Miner", name = "Miner 1.1", version = 1.1, category = Category.MINING)
-public class Miner extends AbstractScript {
+public class Miner extends AbstractScript implements Task {
 
 	Bank bank;
 	Inventory inv;
@@ -266,20 +264,30 @@ public class Miner extends AbstractScript {
 		}
 	}
 
-	public boolean walkOnScreen(Tile t) {
-		getMouse().move(getClient().getViewportTools().tileToScreen(t));
-		String action = getClient().getMenu().getDefaultAction();
-		if (action != null && action.equals("Walk here")) {
-			return getMouse().click();
-		} else {
-			getMouse().click(true);
-			sleepUntil(() -> getClient().getMenu().isMenuVisible(), 600);
-			return getClient().getMenu().clickAction("Walk here");
-		}
-	}
+        public boolean walkOnScreen(Tile t) {
+                getMouse().move(getClient().getViewportTools().tileToScreen(t));
+                String action = getClient().getMenu().getDefaultAction();
+                if (action != null && action.equals("Walk here")) {
+                        return getMouse().click();
+                } else {
+                        getMouse().click(true);
+                        sleepUntil(() -> getClient().getMenu().isMenuVisible(), 600);
+                        return getClient().getMenu().clickAction("Walk here");
+                }
+        }
 
-	private enum State {
-		MINE, DROP, BANK, GUI
-	}
+        @Override
+        public boolean isComplete() {
+                return false;
+        }
+
+        @Override
+        public int execute() {
+                return onLoop();
+        }
+
+        private enum State {
+                MINE, DROP, BANK, GUI
+        }
 
 }

--- a/src/WC/src/WC/Main.java
+++ b/src/WC/src/WC/Main.java
@@ -6,13 +6,10 @@ import org.dreambot.api.methods.container.impl.bank.BankLocation;
 import org.dreambot.api.methods.filter.Filter;
 import org.dreambot.api.methods.map.Area;
 import org.dreambot.api.script.AbstractScript;
-import org.dreambot.api.script.Category;
-import org.dreambot.api.script.ScriptManifest;
 import org.dreambot.api.wrappers.interactive.GameObject;
+import task.Task;
 
-@ScriptManifest(category = Category.WOODCUTTING, name = "WC.01", author = "Andrew", version = .01)
-
-public class Main extends AbstractScript {
+public class Main extends AbstractScript implements Task {
 
 	private State s;
 	private Area bArea, cArea;
@@ -122,11 +119,11 @@ public class Main extends AbstractScript {
 	}
 
 	@Override
-	public int onLoop() {
-		checkState();
-		switch (s.getState()) {
-			case 2: //Cut
-				cut();
+        public int onLoop() {
+                checkState();
+                switch (s.getState()) {
+                        case 2: //Cut
+                                cut();
 				break;
 			case 3:  //Move to bank
 				moveToBank();
@@ -140,7 +137,17 @@ public class Main extends AbstractScript {
 		}
 
 		//RUN EVERY SECOND-ISH
-		return Calculations.random(200, 500);
-	}
+                return Calculations.random(200, 500);
+        }
+
+        @Override
+        public boolean isComplete() {
+                return false;
+        }
+
+        @Override
+        public int execute() {
+                return onLoop();
+        }
 }
 

--- a/src/task/Task.java
+++ b/src/task/Task.java
@@ -1,0 +1,20 @@
+package task;
+
+/**
+ * Represents a unit of work that can be executed by the TaskManager.
+ */
+public interface Task {
+    /**
+     * Returns true if this task has completed its work and should be removed from the queue.
+     *
+     * @return whether the task is complete
+     */
+    boolean isComplete();
+
+    /**
+     * Performs one iteration of this task's work.
+     *
+     * @return the delay before the next execution
+     */
+    int execute();
+}

--- a/src/task/TaskManager.java
+++ b/src/task/TaskManager.java
@@ -1,0 +1,47 @@
+package task;
+
+import java.util.Comparator;
+import java.util.PriorityQueue;
+
+/**
+ * Simple manager that runs tasks in order of priority, advancing when a task completes.
+ */
+public class TaskManager {
+
+    private static class PrioritizedTask {
+        final Task task;
+        final int priority;
+
+        PrioritizedTask(Task task, int priority) {
+            this.task = task;
+            this.priority = priority;
+        }
+    }
+
+    private final PriorityQueue<PrioritizedTask> tasks =
+            new PriorityQueue<>(Comparator.comparingInt((PrioritizedTask pt) -> pt.priority).reversed());
+
+    private PrioritizedTask current;
+
+    /**
+     * Adds a task with the given priority to the queue.
+     */
+    public void addTask(Task task, int priority) {
+        tasks.offer(new PrioritizedTask(task, priority));
+    }
+
+    /**
+     * Executes the current task and advances when it completes.
+     *
+     * @return delay before the next loop iteration
+     */
+    public int onLoop() {
+        if (current == null || current.task.isComplete()) {
+            current = tasks.poll();
+        }
+        if (current == null) {
+            return 600;
+        }
+        return current.task.execute();
+    }
+}

--- a/src/task/TaskManagerScript.java
+++ b/src/task/TaskManagerScript.java
@@ -1,0 +1,37 @@
+package task;
+
+import org.dreambot.api.script.AbstractScript;
+import org.dreambot.api.script.Category;
+import org.dreambot.api.script.ScriptManifest;
+
+@ScriptManifest(category = Category.MISC, name = "TaskManagerScript", author = "Andrew", version = 1.0)
+public class TaskManagerScript extends AbstractScript {
+
+    private TaskManager taskManager;
+
+    @Override
+    public void onStart() {
+        taskManager = new TaskManager();
+
+        Combat.Main combat = new Combat.Main();
+        combat.onStart();
+        taskManager.addTask(combat, 1);
+
+        WC.Main wc = new WC.Main();
+        wc.onStart();
+        taskManager.addTask(wc, 1);
+
+        Craft.Main craft = new Craft.Main();
+        craft.onStart();
+        taskManager.addTask(craft, 1);
+
+        nezz.dreambot.scriptmain.powerminer.Miner miner = new nezz.dreambot.scriptmain.powerminer.Miner();
+        miner.onStart();
+        taskManager.addTask(miner, 1);
+    }
+
+    @Override
+    public int onLoop() {
+        return taskManager.onLoop();
+    }
+}


### PR DESCRIPTION
## Summary
- Introduce a `Task` interface to standardize bot tasks.
- Add `TaskManager` and `TaskManagerScript` to run tasks by priority and handle completion.
- Update Combat, WC, Craft, and Miner scripts to implement the new `Task` interface.

## Testing
- `javac src/task/Task.java src/task/TaskManager.java`
- `javac src/task/TaskManagerScript.java` *(fails: package org.dreambot.api.script does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8421a804832a973fed232ec3e447