### PR TITLE
Add XP monitor and task management

### DIFF
--- a/src/Miner/src/nezz/dreambot/scriptmain/powerminer/MineTask.java
+++ b/src/Miner/src/nezz/dreambot/scriptmain/powerminer/MineTask.java
@@ -1,6 +1,9 @@
 package nezz.dreambot.scriptmain.powerminer;
 
 import java.util.List;
+
+import nezz.dreambot.tasks.Task;
+import nezz.dreambot.tasks.XpMonitor;
 import nezz.dreambot.tools.PricedItem;
 import org.dreambot.api.methods.MethodContext;
 import org.dreambot.api.methods.container.impl.bank.BankLocation;
@@ -11,7 +14,7 @@ import org.dreambot.api.utilities.Timer;
 import org.dreambot.api.wrappers.interactive.GameObject;
 import org.dreambot.api.wrappers.items.Item;
 
-public class MineTask {
+public class MineTask implements Task {
 
 	private String goal = "";
 	private Tile startTile = null;
@@ -65,31 +68,42 @@ public class MineTask {
 		return this.dontMove;
 	}
 
-	public void resetTimer() {
-		t = new Timer();
-	}
+        public void resetTimer() {
+                t = new Timer();
+        }
 
-	public boolean reachedGoal() {
-		if (goal.toLowerCase().contains("bank")) {
-			Item ore = ctx.getBank().get(oreName);
-			if (ore == null) {
-				return false;
-			} else {
-				if (ore.getAmount() >= Integer.parseInt(goal.split("=")[1])) {
-					this.finished = true;
-					return true;
-				}
-				return false;
-			}
-		} else if (goal.toLowerCase().contains("level")) {
-			this.finished = ctx.getSkills().getRealLevel(Skill.MINING) >= Integer.parseInt(goal.split("=")[1]);
-			return finished;
-		} else if (goal.toLowerCase().contains("mine")) {
-			this.finished = oreTracker.getAmount() >= Integer.parseInt(goal.split("=")[1]);
-			return finished;
-		}
-		return false;
-	}
+        @Override
+        public boolean reachedGoal(XpMonitor monitor) {
+                if (goal.toLowerCase().contains("bank")) {
+                        Item ore = ctx.getBank().get(oreName);
+                        if (ore == null) {
+                                return false;
+                        } else {
+                                if (ore.getAmount() >= Integer.parseInt(goal.split("=")[1])) {
+                                        this.finished = true;
+                                        return true;
+                                }
+                                return false;
+                        }
+                } else if (goal.toLowerCase().contains("level")) {
+                        this.finished = monitor.reachedLevel(Skill.MINING, Integer.parseInt(goal.split("=")[1]));
+                        return finished;
+                } else if (goal.toLowerCase().contains("xp")) {
+                        this.finished = monitor.reachedExperience(Skill.MINING, Integer.parseInt(goal.split("=")[1]));
+                        return finished;
+                } else if (goal.toLowerCase().contains("mine")) {
+                        this.finished = oreTracker.getAmount() >= Integer.parseInt(goal.split("=")[1]);
+                        return finished;
+                }
+                return false;
+        }
+
+        @Override
+        public void reset() {
+                resetTimer();
+                oreTracker.setAmount(0);
+                finished = false;
+        }
 
 	private GameObject getClosest(List<GameObject> rocks) {
 		GameObject currRock = null;

--- a/src/Miner/src/nezz/dreambot/scriptmain/powerminer/Miner.java
+++ b/src/Miner/src/nezz/dreambot/scriptmain/powerminer/Miner.java
@@ -5,8 +5,11 @@ import java.awt.Graphics;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.util.List;
+
 import nezz.dreambot.powerminer.gui.ScriptVars;
 import nezz.dreambot.powerminer.gui.minerGui;
+import nezz.dreambot.tasks.TaskManager;
+import nezz.dreambot.tasks.XpMonitor;
 import org.dreambot.api.methods.Calculations;
 import org.dreambot.api.methods.container.impl.Inventory;
 import org.dreambot.api.methods.container.impl.bank.Bank;
@@ -30,11 +33,12 @@ public class Miner extends AbstractScript {
 	//current state
 	private State state;
 	private GameObject currRock = null;
-	//private Tile startTile = null;
-	private MineTask currTask = null;
-	private int taskPlace = 0;
-	private boolean started = false;
-	private minerGui gui = null;
+        //private Tile startTile = null;
+        private MineTask currTask = null;
+        private TaskManager<MineTask> taskManager;
+        private XpMonitor xpMonitor;
+        private boolean started = false;
+        private minerGui gui = null;
 
 	private State getState() {
 		if (!started) {
@@ -51,27 +55,28 @@ public class Miner extends AbstractScript {
 	}
 
 	@Override
-	public void onStart() {
-		getClient().disableIdleCamera();
-		getClient().disableIdleMouse();
-		log("Starting DreamBot AIO Mining script!");
-	}
+        public void onStart() {
+                getClient().disableIdleCamera();
+                getClient().disableIdleMouse();
+                log("Starting DreamBot AIO Mining script!");
+                xpMonitor = new XpMonitor(this);
+        }
 
 	@Override
 	public int onLoop() {
-		if (started) {
-			if (currTask.reachedGoal()) {
-				log("Finished current task!");
-				taskPlace++;
-				if (taskPlace >= sv.tasks.size()) {
-					log("Finished all tasks!");
-					stop();
-					return 1;
-				}
-				currTask = sv.tasks.get(taskPlace);
-				currTask.resetTimer();
-				return 200;
-			}
+                if (started) {
+                        if (taskManager.update(xpMonitor)) {
+                                log("Finished current task! XP/hr: " + xpMonitor.getXpPerHour(Skill.MINING));
+                                if (!taskManager.hasTasks()) {
+                                        log("Finished all tasks!");
+                                        stop();
+                                        return 1;
+                                }
+                                currTask = taskManager.getCurrentTask();
+                                currTask.reset();
+                                xpMonitor.start(Skill.MINING);
+                                return 200;
+                        }
 
 			Player myPlayer = getLocalPlayer();
 			if (!getWalking().isRunEnabled() && getWalking().getRunEnergy() > Calculations.random(30, 70)) {
@@ -100,11 +105,12 @@ public class Miner extends AbstractScript {
 					} else {
 						bank = getBank();
 						inv = getInventory();
-						currTask = sv.tasks.get(0);
-						currTask.resetTimer();
-						getSkillTracker().start(Skill.MINING);
-						timer = new Timer();
-						started = true;
+                                                taskManager = new TaskManager<>(sv.tasks);
+                                                currTask = taskManager.getCurrentTask();
+                                                currTask.reset();
+                                                xpMonitor.start(Skill.MINING);
+                                                timer = new Timer();
+                                                started = true;
 					}
 				}
 				break;

--- a/src/nezz/dreambot/tasks/Task.java
+++ b/src/nezz/dreambot/tasks/Task.java
@@ -1,0 +1,23 @@
+package nezz.dreambot.tasks;
+
+/**
+ * Represents a generic task that can be monitored for experience and level
+ * goals.
+ */
+public interface Task {
+
+    /**
+     * Checks whether this task has reached its goal using the supplied
+     * {@link XpMonitor}.
+     *
+     * @param monitor the monitor to query
+     * @return {@code true} if the goal has been reached
+     */
+    boolean reachedGoal(XpMonitor monitor);
+
+    /**
+     * Resets any internal timers or counters so the task can be executed again.
+     */
+    void reset();
+}
+

--- a/src/nezz/dreambot/tasks/TaskManager.java
+++ b/src/nezz/dreambot/tasks/TaskManager.java
@@ -1,0 +1,41 @@
+package nezz.dreambot.tasks;
+
+import java.util.List;
+
+/**
+ * Simple manager for iterating over a list of {@link Task}s and advancing when a
+ * task's goal has been reached.
+ */
+public class TaskManager<T extends Task> {
+
+    private final List<T> tasks;
+    private int index;
+
+    public TaskManager(List<T> tasks) {
+        this.tasks = tasks;
+        this.index = 0;
+    }
+
+    public T getCurrentTask() {
+        return tasks.get(index);
+    }
+
+    /**
+     * Checks the current task's goal and advances to the next task if necessary.
+     *
+     * @param monitor monitor used for goal detection
+     * @return {@code true} if the manager advanced to the next task
+     */
+    public boolean update(XpMonitor monitor) {
+        if (getCurrentTask().reachedGoal(monitor)) {
+            index++;
+            return true;
+        }
+        return false;
+    }
+
+    public boolean hasTasks() {
+        return index < tasks.size();
+    }
+}
+

--- a/src/nezz/dreambot/tasks/XpMonitor.java
+++ b/src/nezz/dreambot/tasks/XpMonitor.java
@@ -1,0 +1,51 @@
+package nezz.dreambot.tasks;
+
+import org.dreambot.api.methods.MethodProvider;
+import org.dreambot.api.methods.skills.Skill;
+
+/**
+ * Utility class that wraps DreamBot's {@link MethodProvider#getSkillTracker()} to
+ * provide convenient helper methods for monitoring experience gains and levels.
+ */
+public class XpMonitor {
+
+    private final MethodProvider provider;
+
+    public XpMonitor(MethodProvider provider) {
+        this.provider = provider;
+    }
+
+    /**
+     * Starts tracking experience for the given skill.
+     *
+     * @param skill the skill to start tracking
+     */
+    public void start(Skill skill) {
+        provider.getSkillTracker().start(skill);
+    }
+
+    /**
+     * Returns {@code true} if the player has reached the desired level in the
+     * specified skill.
+     */
+    public boolean reachedLevel(Skill skill, int level) {
+        return provider.getSkills().getRealLevel(skill) >= level;
+    }
+
+    /**
+     * Returns {@code true} if the player has gained at least the provided amount
+     * of experience in the specified skill since {@link #start(Skill)} was called.
+     */
+    public boolean reachedExperience(Skill skill, int experience) {
+        return provider.getSkillTracker().getGainedExperience(skill) >= experience;
+    }
+
+    /**
+     * Convenience method for retrieving the gained experience per hour for the
+     * supplied skill.
+     */
+    public int getXpPerHour(Skill skill) {
+        return provider.getSkillTracker().getGainedExperiencePerHour(skill);
+    }
+}
+


### PR DESCRIPTION
## Summary
- wrap DreamBot skill tracker with XpMonitor
- introduce Task and TaskManager for goal-based tasks
- hook Miner script into XpMonitor to switch tasks on goal and log XP/hour

## Testing
- `javac $(find src -name '*.java')` *(fails: package org.dreambot.api... does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8423cc08832abebcbe49e47919e7