### PR TITLE
Replace Zybez price lookup with OSRS Wiki API

### DIFF
--- a/src/Miner/src/nezz/dreambot/tools/PriceGrab.java
+++ b/src/Miner/src/nezz/dreambot/tools/PriceGrab.java
@@ -2,100 +2,109 @@ package nezz.dreambot.tools;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.net.MalformedURLException;
+import java.net.HttpURLConnection;
 import java.net.URL;
-import java.net.URLConnection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
+/**
+ * Utility for grabbing prices from the OSRS Wiki price API.
+ */
 public class PriceGrab {
 
+    private static final String MAPPING_URL = "https://prices.runescape.wiki/api/v1/osrs/mapping";
+    private static final String PRICE_URL = "https://prices.runescape.wiki/api/v1/osrs/latest?id=";
+    private static final String USER_AGENT = "DreamBot PriceGrab";
+    private static final int TIMEOUT = 5000;
 
-	private static PriceGrab oneInstance;
-	private final String zybezUrl = "http://forums.zybez.net/runescape-2007-prices/api/item/";
-	private URL zybez;
-	private URLConnection urlConnection;
-	private BufferedReader inputScan;
+    private static PriceGrab oneInstance;
+    private final Map<String, Integer> nameToId = new HashMap<>();
 
-	public static PriceGrab getInstance() {
-		if (oneInstance == null) {
-			oneInstance = new PriceGrab();
-		}
-		return oneInstance;
-	}
+    public static PriceGrab getInstance() {
+        if (oneInstance == null) {
+            oneInstance = new PriceGrab();
+        }
+        return oneInstance;
+    }
 
-	public int getPrice(String itemName, int command) {
-		final String AVERAGE = "average", LOW = "recent_high", HIGH = "recent_low";
-		String item = format(itemName), extracted;
-		int price = 0;
-		openStream(item);
-		extracted = retrieveData(item);
-		switch (command) {
-			case 1:
-				return parseInfo(extracted, LOW);
+    public int getPrice(String itemName, int command) {
+        if (itemName == null) {
+            return 0;
+        }
+        ensureMappingLoaded();
+        Integer id = nameToId.get(itemName.toLowerCase());
+        if (id == null) {
+            System.out.println("Could not find item id for " + itemName);
+            return 0;
+        }
+        String json = fetchUrl(PRICE_URL + id);
+        if (json == null) {
+            return 0;
+        }
+        int high = parseValue(json, "\"high\":(\\d+)");
+        int low = parseValue(json, "\"low\":(\\d+)");
+        if (high == -1 || low == -1) {
+            System.out.println("Could not retrieve price");
+            return 0;
+        }
+        switch (command) {
+            case 1:
+                return low;
+            case 2:
+                return (high + low) / 2;
+            case 3:
+                return high;
+            default:
+                return 0;
+        }
+    }
 
-			case 2:
-				return parseInfo(extracted, AVERAGE);
+    private void ensureMappingLoaded() {
+        if (!nameToId.isEmpty()) {
+            return;
+        }
+        String json = fetchUrl(MAPPING_URL);
+        if (json == null) {
+            return;
+        }
+        Pattern pattern = Pattern.compile("\\{\\\"id\\\":(\\d+),\\\"name\\\":\\\"([^\\\"]+)\\\"");
+        Matcher matcher = pattern.matcher(json);
+        while (matcher.find()) {
+            int id = Integer.parseInt(matcher.group(1));
+            String name = matcher.group(2).toLowerCase();
+            nameToId.put(name, id);
+        }
+    }
 
-			case 3:
-				return parseInfo(extracted, HIGH);
-		}
-		return price;
-	}
+    protected String fetchUrl(String urlString) {
+        try {
+            URL url = new URL(urlString);
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            connection.setRequestProperty("User-Agent", USER_AGENT);
+            connection.setConnectTimeout(TIMEOUT);
+            connection.setReadTimeout(TIMEOUT);
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
+                StringBuilder sb = new StringBuilder();
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    sb.append(line);
+                }
+                return sb.toString();
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
 
-	private String format(final String string) {
-		if (string.contains(" ")) {
-			return string.replaceAll(" ", "+");
-		} else {
-			return string;
-		}
-	}
-
-	private void openStream(final String param) {
-		String appended = zybezUrl.concat(param);
-
-		try {
-			zybez = new URL(appended);
-			urlConnection = zybez.openConnection();
-			urlConnection.setRequestProperty("User-Agent",
-					"Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.4; en-US; rv:1.9.2.2) Gecko/20100316 Firefox/3.6.2");
-		} catch (MalformedURLException e) {
-			System.out.println("Web address formatted incorrectly, printing stack trace");
-			e.printStackTrace();
-		} catch (IOException exception) {
-			System.out.println("Url connection has thrown an IOException, printing stack trace");
-			exception.printStackTrace();
-		}
-	}
-
-	private String retrieveData(final String param) {
-		String output = null;
-		try {
-			openStream(param);
-			InputStream is = urlConnection.getInputStream();
-			inputScan = new BufferedReader(new InputStreamReader(is));
-			output = inputScan.readLine();
-		} catch (IOException e) {
-			e.printStackTrace();
-		} finally {
-			try {
-				inputScan.close();
-			} catch (IOException e) {
-				e.printStackTrace();
-			}
-		}
-		return output;
-	}
-
-	private int parseInfo(String extracted, String value) {
-		int start, end, price = 0;
-		if (extracted != null && extracted.contains(value)) {
-			start = extracted.indexOf(value);
-			end = extracted.indexOf(",", start);
-			price = Integer.parseInt(extracted.substring(start, end).replaceFirst(".*?(\\d+).*", "$1"));
-		} else {
-			System.out.println("Could not retrieve price");
-		}
-		return price;
-	}
+    private int parseValue(String json, String regex) {
+        Matcher matcher = Pattern.compile(regex).matcher(json);
+        if (matcher.find()) {
+            return Integer.parseInt(matcher.group(1));
+        }
+        return -1;
+    }
 }

--- a/src/Miner/src/nezz/dreambot/tools/PricedItem.java
+++ b/src/Miner/src/nezz/dreambot/tools/PricedItem.java
@@ -18,17 +18,13 @@ public class PricedItem {
 		if (ctx.getInventory().contains(name)) {
 			lastCount = (int) ctx.getInventory().count(name);
 		}
-		if (getPrice) {
-			String tempName = name;
-			if (name.contains("arrow")) {
-				tempName += "s";
-			}
-			MethodProvider.log("Getting price");
-			price = PriceGrab.getInstance().getPrice(tempName, 2);
-			MethodProvider.log("Got price: " + price);
-		} else {
-			price = 0;
-		}
+                if (getPrice) {
+                        MethodProvider.log("Getting price");
+                        price = PriceGrab.getInstance().getPrice(name, 2);
+                        MethodProvider.log("Got price: " + price);
+                } else {
+                        price = 0;
+                }
 	}
 
 	public PricedItem(String name, int id, MethodContext ctx, boolean getPrice) {

--- a/src/Miner/test/nezz/dreambot/tools/PriceGrabTest.java
+++ b/src/Miner/test/nezz/dreambot/tools/PriceGrabTest.java
@@ -1,0 +1,36 @@
+package nezz.dreambot.tools;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class PriceGrabTest {
+    private static class MockPriceGrab extends PriceGrab {
+        @Override
+        protected String fetchUrl(String urlString) {
+            if (urlString.contains("mapping")) {
+                return "[{\"id\":2,\"name\":\"Cannonball\"}]";
+            } else if (urlString.contains("latest")) {
+                return "{\"data\":{\"2\":{\"high\":200,\"low\":100}}}";
+            }
+            return null;
+        }
+    }
+
+    @Test
+    public void testLowPrice() {
+        PriceGrab grab = new MockPriceGrab();
+        assertEquals(100, grab.getPrice("Cannonball", 1));
+    }
+
+    @Test
+    public void testAveragePrice() {
+        PriceGrab grab = new MockPriceGrab();
+        assertEquals(150, grab.getPrice("Cannonball", 2));
+    }
+
+    @Test
+    public void testHighPrice() {
+        PriceGrab grab = new MockPriceGrab();
+        assertEquals(200, grab.getPrice("Cannonball", 3));
+    }
+}


### PR DESCRIPTION
## Summary
- use OSRS Wiki price API with mapping and HTTPS
- add connection timeouts and network error handling
- remove Zybez-specific name tweaks and update tests

## Testing
- `javac -d build/classes src/Miner/src/nezz/dreambot/tools/PriceGrab.java`
- `javac -cp lib/junit-4.13.2.jar:lib/hamcrest-core-1.3.jar:build/classes -d build/test-classes src/Miner/test/nezz/dreambot/tools/PriceGrabTest.java`
- `java -cp lib/junit-4.13.2.jar:lib/hamcrest-core-1.3.jar:build/classes:build/test-classes org.junit.runner.JUnitCore nezz.dreambot.tools.PriceGrabTest`


------
https://chatgpt.com/codex/tasks/task_e_68aca0f5be98832ab6b9a6df55ac86de